### PR TITLE
main push 시 S3+CloudFront 자동 배포 파이프라인 추가

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -1,0 +1,82 @@
+name: Frontend → S3 → CloudFront
+
+on:
+  push:
+    branches: ["main"]   # main 브랜치에 push될 때 실행
+  workflow_dispatch:     # 수동 실행도 가능하게
+
+concurrency:
+  group: frontend-prod   # 같은 그룹 배포가 겹치면 이전 작업 취소
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write    # AWS OIDC 인증용 권한
+      contents: read     # repo 코드 읽기 권한
+
+    steps:
+      # 1. 레포 checkout
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # 2. Node.js 세팅
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20   # Node.js 20 버전 사용
+          cache: 'npm'       # npm 캐싱
+
+      # 3. .env.production 생성
+      - name: Write .env.production
+        run: |
+          cat > .env.production << 'EOF'
+          ${{ secrets.FRONT_ENV }}
+          EOF
+
+      # 4. 의존성 설치
+      - name: Install deps
+        run: npm ci
+
+      # 5. 빌드
+      - name: Build
+        run: npm run build
+
+      # 6. AWS 인증 (OIDC 방식 권장)
+      - name: Configure AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}   # GitHub Actions용 IAM Role ARN
+          aws-region: ap-northeast-2
+
+      # 7. AWS CLI 설치
+      - name: Install AWS CLI v2
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y unzip
+          curl -sS "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install
+
+      # 8. 정적 리소스 업로드 (hash 붙은 js/css 등은 오래 캐시)
+      - name: Upload static assets (long cache)
+        run: |
+          aws s3 sync build s3://ringdongbucket2 \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable" \
+            --exclude "index.html"
+
+      # 9. index.html 업로드 (짧은 캐시)
+      - name: Upload index.html (short cache)
+        run: |
+          aws s3 cp build/index.html s3://ringdongbucket2/index.html \
+            --cache-control "public,max-age=60,no-transform"
+
+      # 10. CloudFront 캐시 무효화 → 배포 즉시 반영
+      - name: CloudFront Invalidation
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"
+


### PR DESCRIPTION
## 프론트엔드 자동 배포 파이프라인 (main 푸시 시)

- **트리거**: main 브랜치에 푸시/머지

- **동작**: GitHub Actions → 빌드 → S3 업로드 → CloudFront 캐시 무효화(전 세계 엣지 즉시 갱신)

- **서빙 구조**: 정적 자산은 **S3(ringdongbucket2)**에 저장되고, 사용자는 **CloudFront(ringdong.kr)**를 통해 접근합니다.

## 배포 흐름

1. main 푸시/머지 → Actions 트리거

2. 빌드 → S3 업로드

3. CloudFront 무효화 → 전 세계 엣지 캐시 갱신

4. 사용자는 ringdong.kr 접속 시 최신 프론트 제공


> 추가한 파일: .github/workflows/front-deploy.yml


## front-deploy.yml 요약

1. I**nstall & Build**: npm ci → npm run build

2. **S3 업로드**: build/ 전체 업로드

3. **캐시 정책**: 해시 파일(*.js, *.css, 이미지 등) → 장기 캐시(Cache-Control: public,max-age=31536000,immutable)

4.** index.html** → 짧은 캐시(최신 반영, public,max-age=60)

5. **CloudFront 무효화**: /* 경로 무효화로 즉시 갱신

6. **환경변수 주입**: GitHub Secrets FRONT_ENV 값을 `.env.production` 파일로 생성 후 빌드에 사용


## 런타임/도메인

프론트: https://ringdong.kr (CloudFront → S3)

백엔드: https://api.ringdong.kr (EC2+Nginx)



## 환경변수

환경변수는 GitHub Secrets에 저장 시 env.production으로 업로드 됩니다.

`저장 위치: GitHub Secrets → FRONT_ENV (.env.production 전체 내용 그대로)`

Secrets 이름: FRONT_ENV
Value 예시: 
```
BACK_API_URL=https://api.ringdong.kr
```


## 롤백

문제 발생 시 레포에서 이전 커밋으로 되돌려 푸시 → 동일 파이프라인이 자동 실행되어 이전 버전으로 재배포됩니다.
