### PR TITLE
fix: 모바일 화면에서 대시보드 셀 겹치는 현상 수정

### DIFF
--- a/src/feature/mandala/pages/MandalaBoard.tsx
+++ b/src/feature/mandala/pages/MandalaBoard.tsx
@@ -13,11 +13,7 @@ import type { ThemeColor } from "@/data/themes";
 import OnboardingTutorial from "@/feature/tutorial/OnboardingTutorial";
 import { useTutorialStore } from "@/lib/stores/tutorialStore";
 import { useAuthStore } from "@/lib/stores/authStore";
-import {
-  handleUpdateMandala,
-  uiToServer,
-  type ServerMandalaType,
-} from "../service";
+import { handleUpdateMandala, type ServerMandalaType } from "../service";
 import { toast } from "sonner";
 
 type MandaraChartProps = {
@@ -53,12 +49,6 @@ export default function MandalaBoard({
   const reminderEnabled = useMandalaStore(
     (state) => state.reminderOption.reminderEnabled
   );
-
-  const reminderOption = useMandalaStore((state) => state.reminderOption);
-  useEffect(() => {
-    console.log(reminderOption);
-    console.log(uiToServer(data, changedCells));
-  }, [data]);
 
   const handleSave = async () => {
     if (!hasSeenReminderSetup && !mandalartId) {
@@ -98,7 +88,7 @@ export default function MandalaBoard({
         <NoticeContainer
           variant={"max"}
           shadow={"xl"}
-          className={cn("backdrop-blur-sm")}
+          className={cn("backdrop-blur-sm pr-4 pl-4")}
         >
           <div className="mailbox-slot"></div>
           <div className="mailbox-flag"></div>
@@ -114,7 +104,7 @@ export default function MandalaBoard({
               목표를 우체통에 넣어 코알라가 정기적으로 리마인드해드려요! 📬
             </p>
           </CardHeader>
-          <CardContent>
+          <CardContent className="px-0">
             <MandalaGrid />
             <div className="text-center mt-6">
               <Button


### PR DESCRIPTION
# fix: 모바일 화면에서 대시보드 셀 겹치는 현상 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- 만다라트 대시보드 스타일 수정

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 모바일 화면(작은 화면)에서 대시보드의 셀들이 겹치는 현상 해결


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->
- 다양한 모바일 환경에서 자연스럽게 대시보드 셀 간격을 조절하는 미디어쿼리 필요

# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #32 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
