### PR TITLE
fix: 만다라트 저장 시 계층 오류 수정

### DIFF
--- a/src/feature/mandala/pages/MandalaBoard.tsx
+++ b/src/feature/mandala/pages/MandalaBoard.tsx
@@ -30,6 +30,7 @@ export default function MandalaBoard({
     (state) => state.hasSeenReminderSetup
   );
   const mandalartId = useMandalaStore((state) => state.mandalartId);
+  const setMandalartId = useMandalaStore((state) => state.setMandalartId);
   const data = useMandalaStore((state) => state.data);
   const changedCells = useMandalaStore((state) => state.changedCells);
   const setData = useMandalaStore((state) => state.setData);
@@ -53,10 +54,12 @@ export default function MandalaBoard({
         toast("변경된 목표가 없습니다!");
         return;
       }
-      const mandalartRes: ServerMandalaType | undefined =
-        await handleUpdateMandala(data, changedCells);
-
-      if (mandalartRes !== undefined) {
+      const mandalartRes: ServerMandalaType = await handleUpdateMandala(
+        data,
+        changedCells
+      );
+      if (mandalartRes.data.mandalartId != undefined) {
+        setMandalartId(mandalartRes.data.mandalartId);
         setData(mandalartRes.data);
         toast.success("만다라트가 저장되었습니다!");
       }


### PR DESCRIPTION
# fix: 만다라트 저장 시 계층 오류 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- mandalart 저장시 res 값에서 mandalartId 저장

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 만다라트 저장 시 id가 없어 계층 오류 문제 해결


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #44 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
