### PR TITLE
fix: 만다라트 대시보드 저장 시 계층 구조 오류 수정/ mandalartId 위치 수정

### DIFF
--- a/src/feature/mandala/pages/MandalaBoard.tsx
+++ b/src/feature/mandala/pages/MandalaBoard.tsx
@@ -59,7 +59,7 @@ export default function MandalaBoard({
         changedCells
       );
       if (mandalartRes.data.mandalartId != undefined) {
-        setMandalartId(mandalartRes.data.mandalartId);
+        setMandalartId(mandalartRes?.data?.mandalartId);
         setData(mandalartRes.data);
         toast.success("만다라트가 저장되었습니다!");
       }

--- a/src/feature/mandala/service/index.ts
+++ b/src/feature/mandala/service/index.ts
@@ -394,8 +394,10 @@ export const uiToServer = (
   id?: number
 ) => {
   const result: {
-    data: { core: Partial<ServerMandalaType["data"]["core"]> };
-    mandalartId?: number;
+    data: {
+      core: Partial<ServerMandalaType["data"]["core"]>;
+      mandalartId?: number;
+    };
   } = {
     data: { core: {} },
   };
@@ -410,7 +412,7 @@ export const uiToServer = (
   }
 
   if (id !== undefined) {
-    result.mandalartId = id;
+    result.data.mandalartId = id;
   }
 
   // 변경된 셀들을 직접 순회하면서 처리


### PR DESCRIPTION
# fix: 만다라트 대시보드 저장 시 계층 구조 오류 수정/ mandalartId 위치 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- mandalartId 계층 위치 수정

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
```ts
// 잘못된 계층 구조
{data:{},mandalartId:0}

// 올바른 계층 구조
{data:{mandalartId:0}}
```
data 객체 안에 mandalartId를 포함하여 전송해야 하기 때문에 구조 이동.


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #51 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
