### PR TITLE
fix: stream api 요청 시 백엔드 서버 url로 가지 않는 이슈 수정

### DIFF
--- a/src/feature/mandala/hooks/useSSERecommendation.tsx
+++ b/src/feature/mandala/hooks/useSSERecommendation.tsx
@@ -27,6 +27,8 @@ const encodingURI = (options: Record<string, string>) => {
   return params.toString();
 };
 
+const baseURL = import.meta.env.VITE_BACKEND_URL;
+
 export default function useSSERecommendation({
   goal,
   count,
@@ -70,7 +72,7 @@ export default function useSSERecommendation({
       parentGoal: goal,
       recommendationCount: count.toString(),
     });
-    const RECOMMEND_URL = `/api/recommend/streaming?${params}`;
+    const RECOMMEND_URL = `${baseURL}/api/recommend/streaming?${params}`;
 
     console.log(`🚀 스트림 연결 시작: ${RECOMMEND_URL}`);
     const eventSource = new EventSource(RECOMMEND_URL, {


### PR DESCRIPTION
# fix: stream api 요청 시 백엔드 서버 url로 가지 않는 이슈 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- baseURL 추가

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 백엔드 서버 url로 요청이 가지 않아 절대 경로로 요청 수정


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #57 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
