### PR TITLE
fix: 한글 입력시 tap 이벤트가 두번 발생되는 이슈 수정

### DIFF
--- a/src/feature/mandala/hooks/useGridTabNavigation.tsx
+++ b/src/feature/mandala/hooks/useGridTabNavigation.tsx
@@ -12,7 +12,9 @@ export default function useGridTabNavigation({
   getNextId,
 }: UseGridTabNavigationProps) {
   useEffect(() => {
+    let isComposing = false;
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (isComposing) return;
       if (e.key !== "Tab") return;
       e.preventDefault();
       if (editingId == undefined) return;
@@ -20,8 +22,14 @@ export default function useGridTabNavigation({
       const nextId = getNextId(editingId);
       if (nextId) setEditingId(nextId);
     };
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("compositionstart", () => {
+      isComposing = true;
+    });
+    window.addEventListener("compositionend", () => {
+      isComposing = false;
+    });
 
+    window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [editingId, setEditingId, getNextId]);
 }


### PR DESCRIPTION
# fix: 한글 입력시 tap 이벤트가 두번 발생되는 이슈 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- Composition 이벤트 감지하여 상태 관리 및 특정 상태에서의 return 처리

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 한글 입력 도중 tap 키를 누르면 한글 조합 처리로 인해 keydown 이벤트가 두번 발생되는 이슈 해결


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #71 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
