### PR TITLE
[Hotfix] 이미지 이슈 발생 전으로 롤백 & 코알라 스탬프 로딩 시에만 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from "react";
+import {
+  handleLogin,
+  handleLogout,
+  reissueWithRefreshToken,
+  shouldAttemptRefresh,
+} from "./feature/auth/service";
+import { useAuthStore } from "./lib/stores/authStore";
+import MandalaBoard from "./feature/mandala/pages/MandalaBoard";
+import useTheme from "./shared/hooks/useTheme";
+import { handleMandalaData } from "./feature/mandala/service";
+import { APIWithRetry, getURLQuery } from "./feature/auth/\butils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { Toaster } from "./feature/ui/Sonner";
+import { toast } from "sonner";
+import Header from "./shared/\bcomponents/header/Header";
+import { useTutorialStore } from "./lib/stores/tutorialStore";
+import OnboardingTutorial from "./feature/tutorial/page";
+import useResize from "./shared/hooks/useResize";
+import AuthComponent from "./feature/auth/components/AuthComponent";
+import HomePage from "./feature/home/pages/HomePage";
+
+const queryClient = new QueryClient();
+
+function App() {
+  useResize();
+  const { currentTheme, updateCurrentTheme, getCurrentBackground } = useTheme();
+  const wasLoggedIn = useAuthStore((state) => state.wasLoggedIn);
+  const isAuthOpen = useAuthStore((state) => state.isAuthOpen);
+  const temporaryAuth = useAuthStore((state) => state.temporaryAuth);
+  const authComponentText = useAuthStore((state) => state.authComponentText);
+  const isOnboardingOpen = useTutorialStore((state) => state.isOnboardingOpen);
+  const setTemporaryAuth = useAuthStore((state) => state.setTemporaryAuth);
+
+  useEffect(() => {
+    const initApp = async () => {
+      try {
+        // 최초 로그인
+        const tokenFromURL = getURLQuery("access_token");
+        if (tokenFromURL) {
+          handleLogin();
+          await handleMandalaData();
+          return;
+        }
+
+        // 새로고침 / 재접속이라면 refresh 시도
+        if (shouldAttemptRefresh()) {
+          const success = await APIWithRetry(reissueWithRefreshToken);
+          if (!success) {
+            handleLogout();
+            toast("세션 종료로 인해 처음 화면으로 돌아갑니다.");
+            return;
+          }
+          setTemporaryAuth("loggedIn");
+          await handleMandalaData();
+        }
+      } catch (error) {
+        console.error("Auth initialization failed:", error);
+        setTemporaryAuth("none");
+      }
+    };
+    initApp();
+  }, []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Header currentTheme={currentTheme} onThemeChange={updateCurrentTheme} />
+
+      {temporaryAuth !== "none" || wasLoggedIn ? (
+        <MandalaBoard getCurrentBackground={getCurrentBackground} />
+      ) : (
+        <HomePage getCurrentBackground={getCurrentBackground} />
+      )}
+
+      <Toaster position="top-center" />
+      {isOnboardingOpen && <OnboardingTutorial />}
+      {isAuthOpen && !wasLoggedIn && (
+        <AuthComponent>{authComponentText}</AuthComponent>
+      )}
+
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}
+
+export default App;

--- a/src/feature/home/pages/HomePage.tsx
+++ b/src/feature/home/pages/HomePage.tsx
@@ -3,7 +3,7 @@ import StoryBoardComponents from "../components/StoryBoardComponents";
 import Button from "../../ui/Button";
 import BackgroundAnimation from "../components/BackgroundAnimation";
 import { useViewportStore } from "@/lib/stores/viewportStore";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useAuthStore } from "@/lib/stores/authStore";
 import useAccessibility from "@/shared/hooks/useAccessibility";
 import useVisibility from "@/shared/hooks/useVisibility";
@@ -13,10 +13,9 @@ type MandaraChartProps = {
 };
 
 export default function HomePage({ getCurrentBackground }: MandaraChartProps) {
-  const [lcpDone, setLcpDone] = useState(false);
   const setTemporaryAuth = useAuthStore((state) => state.setTemporaryAuth);
   const height = useViewportStore((state) => state.height);
-  const { backgroundImage, srcSet } = getCurrentBackground();
+  const { mobile, desktop } = getCurrentBackground();
   const reduced = useAccessibility(); // default: false
   const inactiveTab = useVisibility(); // default: false
   const isMobile = useViewportStore((state) => state.isMobile);
@@ -31,35 +30,45 @@ export default function HomePage({ getCurrentBackground }: MandaraChartProps) {
     document.documentElement.style.setProperty("--real-vh", `${height}`);
   }, [height]);
 
-  useEffect(() => {
-    requestIdleCallback(() => setLcpDone(true));
-  }, []);
-
   return (
     <div className="min-h-screen relative overflow-hidden">
       {/* 메인 로그인 섹션 */}
       <div className="min-h-screen flex flex-col items-center justify-center px-4 relative">
-        {/* 배경 이미지 */}
-        <div
-          aria-hidden="true"
-          role="presentation"
-          className="absolute inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-scroll h-[var(--real-vh)]"
-        >
+        {/* 모바일 배경 이미지 */}
+        <div className="absolute inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-scroll h-[var(--real-vh)]">
+          <h1>
+            <picture>
+              <source srcSet={mobile} media="(min-width: 768px)" />
+              <img
+                className="fixed inset-0 w-full h-full object-cover -z-10"
+                srcSet={mobile}
+                src={mobile}
+                alt="만다라트 목표 작성 & 리마인드 | 코알라 우체부"
+              />
+            </picture>
+            <span className="sr-only">
+              만다라트 목표 작성 & 리마인드 | 코알라 우체부
+            </span>
+          </h1>
+        </div>
+        {/* 데스크탑 배경 이미지 */}
+        <div className="absolute inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-fixed">
           <picture>
-            <source srcSet={srcSet} />
+            <source srcSet={desktop} media="(min-width: 1200px)" />
             <img
               className="fixed inset-0 w-full h-full object-cover -z-10"
-              src={backgroundImage[0]}
-              alt="만다라트 목표 작성 & 리마인드 | 코알라 우체부"
+              src={desktop}
+              srcSet={desktop}
+              alt="테마 배경 이미지"
             />
           </picture>
         </div>
 
+        {/* 날아가는 코알라 애니메이션 */}
+        {!reduced && !inactiveTab && <BackgroundAnimation />}
+
         {/* 메인 로그인 컨테이너 */}
         <MainSection onTemporaryLogin={setTemporaryAuth} />
-
-        {/* 날아가는 코알라 애니메이션 */}
-        {lcpDone && !reduced && !inactiveTab && <BackgroundAnimation />}
       </div>
 
       {/* 서비스 소개 섹션 */}

--- a/src/feature/mandala/components/MandalaReadOnlyCell.tsx
+++ b/src/feature/mandala/components/MandalaReadOnlyCell.tsx
@@ -135,7 +135,7 @@ export default function MandalaReadOnlyCell({
           className="absolute w-full h-full p-1 shadow-[inset_0_2px_4px_0_rgba(0,0,0,0.05)] "
           style={{ backgroundColor: "rgba(219, 219, 219, 0.6)" }}
         >
-          {koalaSeal && <img src={koalaSeal} alt="해당 목표 완료했습니다." />}
+          <img src={koalaSeal[0]} alt="해당 목표 완료했습니다." />
         </div>
       )}
     </div>

--- a/src/lib/stores/authStore.ts
+++ b/src/lib/stores/authStore.ts
@@ -44,10 +44,7 @@ export const useAuthStore = create<States & Actions>()(
     (set, get) => ({
       accessToken: null,
       temporaryAuth: "none",
-      wasLoggedIn:
-        typeof window !== "undefined"
-          ? localStorage.getItem("wasLoggedIn") === "true"
-          : false,
+      wasLoggedIn: false,
       lastProvider: null,
       lastLoginTime: "",
       user: {

--- a/src/lib/stores/mandalaStore.ts
+++ b/src/lib/stores/mandalaStore.ts
@@ -143,8 +143,8 @@ export const useMandalaStore = create<States & Actions>()(
             const isSubsComplete = mains[mainIndex].subs
               .slice(1)
               .every((item) => item.status === "DONE");
-            const isCenterTextWritten = mains[mainIndex].subs[0].content !== "";
-            if (isSubsComplete && isCenterTextWritten) {
+
+            if (isSubsComplete) {
               const { mainId, newMain } = toggleStatus(
                 "DONE",
                 mains,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./styles/globals.css";
+import "./styles/loading_ui.css";
+import App from "./App.tsx";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -27,7 +27,7 @@ export default function Header({
   );
 
   return (
-    <div className="w-full mb-4 sm:mb-6 lg:mb-8 px-4 p-4 fixed z-[999]">
+    <div className="w-full mb-4 sm:mb-6 lg:mb-8 px-4 p-4 fixed z-[1]">
       <div
         className={cn(
           "mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4 w-full justify-end"

--- a/src/shared/hooks/useResize.tsx
+++ b/src/shared/hooks/useResize.tsx
@@ -5,7 +5,6 @@ export default function useResize() {
   const setViewport = useViewportStore((state) => state.setViewport);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
     const handleResize = () => {
       const width = window.innerWidth;
       const height = window.innerHeight;

--- a/src/shared/hooks/useTheme.tsx
+++ b/src/shared/hooks/useTheme.tsx
@@ -15,7 +15,7 @@ const THEME_STORAGE_KEY = "koalart_theme";
 
 export default function useTheme() {
   const [currentTheme, setCurrentTheme] = useState(() => {
-    if (typeof window === "undefined") return findInTheFourSeasons();
+    if (!window) return findInTheFourSeasons();
     const saveColor = window.localStorage.getItem(
       THEME_STORAGE_KEY
     ) as ThemeColor;
@@ -25,7 +25,6 @@ export default function useTheme() {
   });
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
     updateCurrentTheme(currentTheme);
   }, [currentTheme]);
 


### PR DESCRIPTION
# [Hotfix] 이미지 이슈 발생 전으로 롤백 
<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- SSR/SSG 로 변경하기 이전 코드로 복구
- 코알라 도장 이미지가 로딩되었을 때만 노출하고, 이미지 로딩 실패 시에는 배경 효과만 적용하도록 수정

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- SSR/SSG로 구조를 변경하면서 이미지 로딩에 문제가 생겼기 때문에 이를 위해 이전 코드로 복구함.


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->
- SSR/SSG 로 변경한 이후의 이미지 로딩 검증이 필요해보임.
- 주요 목표가 작성 되어야 모든 목표에 스탬프를 찍도록 로직을 변경했으나, 실시간 동기화가 안되고 있음. 따라서 목표 content를 작성할 때 검사하는 로직의 타이밍을 고려해봐야함.
# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
