### PR TITLE
[Feature] 모든 요소의 css를 적용하도록 순회하는 로직 추가

### DIFF
--- a/src/feature/mandala/utills/image.ts
+++ b/src/feature/mandala/utills/image.ts
@@ -2,6 +2,28 @@
 import { toPng } from "html-to-image";
 import { toast } from "sonner";
 
+const copyComputedStyles = (
+  originalElement: HTMLElement,
+  clonedElement: HTMLElement
+) => {
+  const originalElements = originalElement.querySelectorAll("*");
+  const clonedElements = clonedElement.querySelectorAll("*");
+
+  originalElements.forEach((original, index) => {
+    const computedStyle = window.getComputedStyle(original);
+    const clonedEl = clonedElements[index] as HTMLElement;
+    console.log(computedStyle);
+
+    Array.from(computedStyle).forEach((style) => {
+      clonedEl.style.setProperty(
+        style,
+        computedStyle.getPropertyValue(style),
+        computedStyle.getPropertyPriority(style)
+      );
+    });
+  });
+};
+
 export const captureAndDownload = async (
   mandaraGridRef: React.RefObject<HTMLDivElement | null>
 ) => {
@@ -18,22 +40,16 @@ export const captureAndDownload = async (
   tempContainer.style.overflow = "visible";
   tempContainer.style.width = "max-content";
   tempContainer.style.height = "max-content";
+  tempContainer.style.paddingTop = "50px";
+  tempContainer.style.paddingBottom = "50px";
 
   document.body.appendChild(tempContainer);
 
   try {
     const clonedElement = originalElement.cloneNode(true) as HTMLElement;
 
-    clonedElement.style.overflow = "visible";
-    clonedElement.style.maxHeight = "none";
-    clonedElement.style.height = "auto";
-
-    const allElements = clonedElement.querySelectorAll("*");
-    allElements.forEach((el) => {
-      const htmlEl = el as HTMLElement;
-      htmlEl.style.overflow = "visible";
-      htmlEl.style.maxHeight = "none";
-    });
+    await document.fonts.ready;
+    copyComputedStyles(originalElement, clonedElement);
 
     tempContainer.appendChild(clonedElement);
 
@@ -52,8 +68,6 @@ export const captureAndDownload = async (
       .slice(0, 10)}.png`;
     link.href = dataUrl;
     link.click();
-
-    toast("만다라트 이미지가 저장되었습니다!");
   } catch (error) {
     console.error("이미지 저장 중 오류:", error);
     toast.error(


### PR DESCRIPTION
# [Feature] 모든 요소의 css를 적용하도록 순회하는 로직 추가

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
 - 모든 요소 순회하여 인라인 css 적용

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->


### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 테일윈드로 css를 인라인 적용하여 이미지 캡쳐했을 때, 누락되는 요소들이 있었음. 따라서 모든 요소를 순회하여 인라인 css를 적용함


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->
- 반응형에 따라 css 요소가 변경되므로, 뷰포트가 달라지면, 화면에 따라 이미지 캡쳐를 하기 때문에 크기가 매번 달라짐.
- 모바일에서 캡쳐 시에 데스크탑 사이즈로 캡쳐할 지에 대한 논의 필요

# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
