### PR TITLE
[Fix] 신규 가입자의 빈 대시보드 생성 로직 추가

### DIFF
--- a/src/feature/mandala/api/mandalart/getMandala.ts
+++ b/src/feature/mandala/api/mandalart/getMandala.ts
@@ -12,5 +12,6 @@ export const getMandalaAPI = async (accessToken: string) => {
     return res;
   } catch (error) {
     console.error("getMandalaAPI failed:", error);
+    throw error;
   }
 };

--- a/src/feature/mandala/hooks/useMandalaData.tsx
+++ b/src/feature/mandala/hooks/useMandalaData.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getMandalaAPI } from "../api/mandalart/getMandala";
-import { type ServerMandalaType } from "../service";
+import { emptyDummyData, type ServerMandalaType } from "../service";
 import { useAuthStore } from "@/lib/stores/authStore";
 
 export default function useMandalaData() {
@@ -13,7 +13,14 @@ export default function useMandalaData() {
         throw new Error("Mandala Data: accessToken이 없습니다.");
       }
 
-      return getMandalaAPI(accessToken);
+      const res = getMandalaAPI(accessToken);
+
+      // 상태 코드 체크
+      if (res === null) {
+        return emptyDummyData;
+      }
+
+      return res;
     },
     enabled: !!accessToken,
     staleTime: Infinity,


### PR DESCRIPTION
# [Fix] 신규 가입자의 빈 대시보드 생성 로직 추가

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- 만다라트 대시보드 api에 에러 객체 그대로 throw
- 데이터가 null일 시 빈 대시보드 데이터 생성하여 반환

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 신규 가입자의 경우 204 not found가 도착하여 null이 반환되므로, null 캐치 시 빈 대시보드 데이터를 생성하여 반환한다.


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #109 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
