### PR TITLE
[Fix] 대시보드 결과값이 null 일 시 빈 대시보드 반환

### DIFF
--- a/src/feature/mandala/hooks/useMandalaData.tsx
+++ b/src/feature/mandala/hooks/useMandalaData.tsx
@@ -8,18 +8,15 @@ export default function useMandalaData() {
 
   return useQuery({
     queryKey: ["mandalart"],
-    queryFn: () => {
+    queryFn: async () => {
       if (!accessToken) {
         throw new Error("Mandala Data: accessToken이 없습니다.");
       }
 
-      const res = getMandalaAPI(accessToken);
-
-      // 상태 코드 체크
+      const res = await getMandalaAPI(accessToken);
       if (res === null) {
         return emptyDummyData;
       }
-
       return res;
     },
     enabled: !!accessToken,


### PR DESCRIPTION
# [Fix] 대시보드 결과값이 null 일 시 빈 대시보드 반환

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- useMandalaData 훅의 queryFn에 대시보드 빈 데이터 반환 로직 추가

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 신규 가입자 일 시 204 상태 코드로 인해 결과값이 없어 error 발생 후 바로 로그아웃 되는 문제 해결


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #109 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
