### PR TITLE
[Fix]: 로그인 화면 삭제 및 대시보드 화면을 메인으로 수정

### DIFF
--- a/src/feature/auth/components/AuthGateway.tsx
+++ b/src/feature/auth/components/AuthGateway.tsx
@@ -3,7 +3,6 @@ import useRefresh from "../hooks/useRefresh";
 import { useEffect } from "react";
 import { handleLogout } from "../service";
 import { toast } from "sonner";
-import HomePage from "@/feature/home/pages/HomePage";
 import MandalaBoard from "@/feature/mandala/pages/MandalaBoard";
 import useUserInfo from "../hooks/useUserInfo";
 
@@ -12,8 +11,6 @@ type Props = {
 };
 
 export default function AuthEntry({ getCurrentBackground }: Props) {
-  const accessToken = useAuthStore((state) => state.accessToken);
-  const temporaryAuth = useAuthStore((state) => state.temporaryAuth);
   const setAccessToken = useAuthStore((state) => state.setAccessToken);
   const setWasLoggedIn = useAuthStore((state) => state.setWasLoggedIn);
   const setLastLoginTime = useAuthStore((state) => state.setLastLoginTime);
@@ -50,10 +47,12 @@ export default function AuthEntry({ getCurrentBackground }: Props) {
     }
   }, [userInfo, isUserReady]);
 
-  if (temporaryAuth === "temporary")
-    return <MandalaBoard getCurrentBackground={getCurrentBackground} />;
-  if (temporaryAuth === "loggedIn" && accessToken)
-    return <MandalaBoard getCurrentBackground={getCurrentBackground} />;
+  return <MandalaBoard getCurrentBackground={getCurrentBackground} />;
 
-  return <HomePage getCurrentBackground={getCurrentBackground} />;
+  // if (temporaryAuth === "temporary")
+  //   return <MandalaBoard getCurrentBackground={getCurrentBackground} />;
+  // if (temporaryAuth === "loggedIn" && accessToken)
+  // return <MandalaBoard getCurrentBackground={getCurrentBackground} />;
+
+  // return <HomePage getCurrentBackground={getCurrentBackground} />;
 }

--- a/src/feature/home/pages/HomePage.tsx
+++ b/src/feature/home/pages/HomePage.tsx
@@ -1,29 +1,20 @@
 import MainSection from "../components/MainSection";
-import BackgroundAnimation from "../components/BackgroundAnimation";
 import { useViewportStore } from "@/lib/stores/viewportStore";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useAuthStore } from "@/lib/stores/authStore";
-import useAccessibility from "@/shared/hooks/useAccessibility";
-import useVisibility from "@/shared/hooks/useVisibility";
 
 type MandaraChartProps = {
   getCurrentBackground: () => Record<string, string>;
 };
 
 export default function HomePage({ getCurrentBackground }: MandaraChartProps) {
-  const [lcpDone, setLcpDone] = useState(false);
   const setTemporaryAuth = useAuthStore((state) => state.setTemporaryAuth);
   const height = useViewportStore((state) => state.height);
   const { backgroundImage, srcSet } = getCurrentBackground();
-  const reduced = useAccessibility(); // default: false
-  const inactiveTab = useVisibility(); // default: false
 
   useEffect(() => {
     document.documentElement.style.setProperty("--real-vh", `${height}`);
   }, [height]);
-  useEffect(() => {
-    requestIdleCallback(() => setLcpDone(true));
-  }, []);
 
   return (
     <div className="min-h-screen relative overflow-hidden">
@@ -49,7 +40,7 @@ export default function HomePage({ getCurrentBackground }: MandaraChartProps) {
         <MainSection onTemporaryLogin={setTemporaryAuth} />
 
         {/* 날아가는 코알라 애니메이션 */}
-        {lcpDone && !reduced && !inactiveTab && <BackgroundAnimation />}
+        {/* {lcpDone && !reduced && !inactiveTab && <BackgroundAnimation />} */}
       </div>
 
       {/* 서비스 소개 섹션 */}

--- a/src/feature/mandala/pages/MandalaBoard.tsx
+++ b/src/feature/mandala/pages/MandalaBoard.tsx
@@ -14,9 +14,6 @@ import MailIcon from "../components/icon/MailIcon";
 import ActivationBellIcon from "../components/icon/ActivationBellIcon";
 import DisableBellIcon from "../components/icon/DisableBellIcon";
 import FullIcon from "../components/icon/FullIcon";
-import BackgroundAnimation from "@/feature/home/components/BackgroundAnimation";
-import useAccessibility from "@/shared/hooks/useAccessibility";
-import useVisibility from "@/shared/hooks/useVisibility";
 import { KoalaTextLogo, KoalaTextLogoSrcSet } from "../const/url";
 import useMandalaData from "../hooks/useMandalaData";
 import { handleLogout } from "@/feature/auth/service";
@@ -30,8 +27,6 @@ export default function MandalaBoard({
   getCurrentBackground,
 }: MandaraChartProps) {
   const { backgroundImage, srcSet } = getCurrentBackground();
-  const reduced = useAccessibility(); // default: false
-  const inactiveTab = useVisibility(); // default: false
 
   const accessToken = useAuthStore((state) => state.accessToken);
   const wasLoggedIn = useAuthStore((state) => state.wasLoggedIn);
@@ -103,7 +98,6 @@ export default function MandalaBoard({
 
   return (
     <div className="relative min-h-screen p-4 pt-[51px] ">
-      {!reduced && !inactiveTab && <BackgroundAnimation />}
       {/* 배경 이미지 */}
       <div
         aria-hidden="true"

--- a/src/shared/components/header/Header.tsx
+++ b/src/shared/components/header/Header.tsx
@@ -20,7 +20,6 @@ export default function Header({
 }: MandaraChartProps) {
   const accessToken = useAuthStore((state) => state.accessToken);
   const wasLoggedIn = useAuthStore((state) => state.wasLoggedIn);
-  const temporaryAuth = useAuthStore((state) => state.temporaryAuth);
   const setAuthOpen = useAuthStore((state) => state.setAuthOpen);
   const setAuthText = useAuthStore((state) => state.setAuthText);
   const setOnboardingVisible = useTutorialStore(
@@ -41,32 +40,28 @@ export default function Header({
         )}
       >
         <div className="flex flex-wrap gap-2 w-full sm:w-auto">
-          {temporaryAuth !== "none" && (
-            <>
-              <Button
-                variant="outline"
-                size="default"
-                onClick={() => setServiceIntroVisible(!isServiceIntroOpen)}
-                className="flex items-center gap-1 sm:gap-2 pixel-button bg-white/90 backdrop-blur-sm text-xs sm:text-sm px-2 sm:px-4 "
-                dir="ltr"
-              >
-                <span className="hidden sm:inline">서비스 소개</span>
-                <span className="sm:hidden">서비스 소개</span>
-              </Button>
-              <Button
-                variant="outline"
-                size="default"
-                onClick={() => setOnboardingVisible(true)}
-                className="flex items-center gap-1 sm:gap-2 pixel-button bg-white/90 backdrop-blur-sm text-xs sm:text-sm px-2 sm:px-4 "
-                dir="ltr"
-              >
-                <AddressBook />
+          <Button
+            variant="outline"
+            size="default"
+            onClick={() => setServiceIntroVisible(!isServiceIntroOpen)}
+            className="flex items-center gap-1 sm:gap-2 pixel-button bg-white/90 backdrop-blur-sm text-xs sm:text-sm px-2 sm:px-4 "
+            dir="ltr"
+          >
+            <span className="hidden sm:inline">서비스 소개</span>
+            <span className="sm:hidden">서비스 소개</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="default"
+            onClick={() => setOnboardingVisible(true)}
+            className="flex items-center gap-1 sm:gap-2 pixel-button bg-white/90 backdrop-blur-sm text-xs sm:text-sm px-2 sm:px-4 "
+            dir="ltr"
+          >
+            <AddressBook />
 
-                <span className="hidden sm:inline">튜토리얼</span>
-                <span className="sm:hidden">?</span>
-              </Button>
-            </>
-          )}
+            <span className="hidden sm:inline">튜토리얼</span>
+            <span className="sm:hidden">?</span>
+          </Button>
           <ThemeSelector
             currentTheme={currentTheme}
             onThemeChange={onThemeChange}


### PR DESCRIPTION
# [Fix]: 로그인 화면 삭제 및 대시보드 화면을 메인으로 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- 메인 보드 컴포넌트를 로그인 상관없이 렌더링하도록 수정
- header의 튜토리얼, 서비스 소개 버튼을 항시 렌더링하도록 수정
- 배경 애니메이션 해지 및 애니메이션 관련 훅들 제거



### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 대시보드 화면을 메인 화면으로 기획 수정하면서 컴포넌트 구조 변경 및 관련 로직 삭제(주석)


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
