### PR TITLE
[Chore]: 이미지 LCP 요소 설정 및 div 속성 삭제

### DIFF
--- a/src/feature/home/components/ServiceIntroComponent.tsx
+++ b/src/feature/home/components/ServiceIntroComponent.tsx
@@ -28,11 +28,7 @@ Props) {
   //   };
   return (
     <div className="w-full h-full py-20 px-4 absolute top-0 z-20 ">
-      <div
-        aria-hidden="true"
-        role="presentation"
-        className="background fixed inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-scroll h-[var(--real-vh)]"
-      >
+      <div className="background fixed inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-scroll h-[var(--real-vh)]">
         {/* <picture>
           <source srcSet={srcSet} />
           <img

--- a/src/feature/mandala/pages/MandalaBoard.tsx
+++ b/src/feature/mandala/pages/MandalaBoard.tsx
@@ -98,11 +98,7 @@ MandaraChartProps) {
   return (
     <div className="relative min-h-screen p-4 pt-[51px] ">
       {/* 배경 이미지 */}
-      <div
-        aria-hidden="true"
-        role="presentation"
-        className="background absolute inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-scroll h-[var(--real-vh)]"
-      >
+      <div className="background absolute inset-0 min-h-screen z-[-1000] pointer-events-none md:block bg-cover bg-center bg-no-repeat bg-scroll h-[var(--real-vh)]">
         {/* <picture>
           <source srcSet={srcSet} />
           <img
@@ -123,7 +119,8 @@ MandaraChartProps) {
           <img
             src={KoalaTextLogo[0]}
             className="w-full"
-            loading="lazy"
+            loading="eager"
+            fetchPriority="high"
             decoding="async"
             srcSet={KoalaTextLogoSrcSet}
             sizes="(max-width: 768px) 90vw, 476px"


### PR DESCRIPTION
# [Chore]: 이미지 LCP 요소 설정 및 div 속성 삭제

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- 이미지에 loading="eager", fetchPriority="high" 속성 추가           

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 이미지에 alt 추가로 인한 LCP 요소 선택 발생 > 이미지가 뒤늦게 로드되어 성능 점수(LCP)에 영향을 주게 되어 미리 로드하도록 속성 변경


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- #119 

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
