### PR TITLE
[Fix] sitemap URL trailing slash 제거 (리디렉션 방지)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://ringdong.kr/</loc>
+    <loc>https://ringdong.kr</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>


### PR DESCRIPTION
# [Fix] sitemap URL trailing slash 제거 (리디렉션 방지)

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- sitemap url 수정(https://ringdong.kr`/` -> https://ringdong.kr)

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- https://ringdong.kr`/`으로 인해 구글에서 실제 url과 다르게 판단하여(리디렉션 페이지라고 판단) 색인 요청이 거부되는 문제 해결


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
