### PR TITLE
[Fix] 의존성 추적 > changeCells에 goalId 추가 안 되는 문제 해결

### DIFF
--- a/src/feature/mandala/components/full/FullCell.tsx
+++ b/src/feature/mandala/components/full/FullCell.tsx
@@ -53,7 +53,7 @@ export default React.memo(function ModalCell({
       //   textarea.style.height = textarea.scrollHeight + "px";
       // }
     },
-    [goalId, handleCellChange]
+    [goalId, handleCellChange, data]
   );
 
   // useEffect(() => {

--- a/src/feature/mandala/components/grid/GridCell.tsx
+++ b/src/feature/mandala/components/grid/GridCell.tsx
@@ -60,7 +60,7 @@ export default React.memo(function GridCell({
       //   textarea.style.height = textarea.scrollHeight + "px";
       // }
     },
-    [goalId, handleCellChange]
+    [goalId, handleCellChange, data]
   );
 
   // useEffect(() => {

--- a/src/feature/mandala/components/modal/ModalCell.tsx
+++ b/src/feature/mandala/components/modal/ModalCell.tsx
@@ -54,7 +54,7 @@ export default React.memo(function ModalCell({
       //   textarea.style.height = textarea.scrollHeight + "px";
       // }
     },
-    [goalId, handleCellChange]
+    [goalId, handleCellChange, data]
   );
   const onGoalClick = (e: React.MouseEvent) => {
     e.stopPropagation();


### PR DESCRIPTION
# [Fix] 의존성 추적 > changeCells에 goalId 추가 안 되는 문제 해결

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
handleContentChange 함수의 의존성 배열에 query data의 누락으로 changeCells에 goalId가 추가되지 않는 문제가 발생했습니다. 의존성 배열에 data를 추가하여 추적하도록 변경했습니다.

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- handleContentChange 의존성 배열에 data 추가

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->
- 의존성 누락으로 인해 queryData의 참조가 불가능하여 새로운 대시보드 목표를 서버에 저장할 수 없는 문제 발생.


### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
