### PR TITLE
[Feature] sitemap 갱신 스크립트 추가(기존 자동배포 스크립트 비활성화)

### DIFF
--- a/.github/workflows/update-sitemap.yml
+++ b/.github/workflows/update-sitemap.yml
@@ -1,0 +1,41 @@
+name: update-sitemap
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "**.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sitemap
+  cancel-in-progress: true
+
+jobs:
+  update-sitemap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run update-sitemap
+        env:
+          CI: true
+      - run: |
+          if git diff --quiet public/sitemap.xml; then
+            echo "변경 없음"
+          else
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add public/sitemap.xml
+            git commit -m "chore: update sitemap [skip ci]"
+            git pull --rebase origin main
+            git push
+          fi


### PR DESCRIPTION
# [Feature] sitemap 갱신 스크립트 추가(기존 자동배포 스크립트 비활성화)

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
CloudFront를 사용하여 진행한 자동배포를 비활성화합니다. Cloudflare Pages로 호스팅을 이전하여, 자동배포가 필요없어져 스크립트를 사용하지 않습니다. 따라서 sitemap 갱신용 스크립트를 분리하여 새롭게 추가했습니다. 

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->


### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->



### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
