### PR TITLE
[Fix] 로그인 흐름 수정

### DIFF
--- a/src/feature/auth/hooks/useLogin.tsx
+++ b/src/feature/auth/hooks/useLogin.tsx
@@ -1,6 +1,8 @@
 import { useAuthStore } from "@/lib/stores/authStore";
 import { useEffect } from "react";
 import { clearURLQuery, getURLQuery } from "../\butils";
+import { refreshTokenAPI } from "../api";
+import { validateOAuthState } from "../service";
 import { toast } from "sonner";
 
 export default function useOAuthCallback() {
@@ -9,18 +11,31 @@ export default function useOAuthCallback() {
   const setLastLoginTime = useAuthStore((s) => s.setLastLoginTime);
 
   useEffect(() => {
-    const errorFromUrl = getURLQuery("error");
-    if (errorFromUrl) {
-      toast.error("로그인에 실패했습니다. 다시 시도해주세요.");
-      clearURLQuery();
-      return;
-    }
-    const token = getURLQuery("access_token");
-    if (!token) return;
+    (async () => {
+      const errorFromUrl = getURLQuery("error");
+      console.log(errorFromUrl);
+      if (errorFromUrl) {
+        toast.error("로그인에 실패했습니다. 다시 시도해주세요.");
+        clearURLQuery();
+        return;
+      }
+      // const token = getURLQuery("access_token");
 
-    setAccessToken(token);
-    setWasLoggedIn(true);
-    setLastLoginTime(new Date().toISOString());
-    clearURLQuery();
+      const state = getURLQuery("state");
+      if (state) {
+        const isValidState = validateOAuthState(state);
+        console.log(isValidState);
+        if (isValidState) {
+          const accessToken = await refreshTokenAPI();
+          if (!accessToken) return;
+
+          setAccessToken(accessToken);
+          setWasLoggedIn(true);
+          setLastLoginTime(new Date().toISOString());
+        }
+      }
+
+      clearURLQuery();
+    })();
   }, []);
 }


### PR DESCRIPTION


# 제목 (Title)

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
기존 쿼리에 access token을 받아와 로그인하던 노출식에서 
state를 사용하여 CSRF를 사전 방지하고 access token을 refresh token으로 받아오는 안전한 방식으로 교체했습니다. 

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- state 확인 후 refresh token을 이용한 access token 통신

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->



### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
