### PR TITLE
[Fix] 로그인 흐름 변경

### DIFF
--- a/src/feature/auth/api.ts
+++ b/src/feature/auth/api.ts
@@ -22,13 +22,10 @@ export const refreshTokenAPI = async () => {
   const REFRESH_URL = "/api/auth/refresh";
 
   try {
-    const res = await apiClient.post<RefreshType>(
-      REFRESH_URL,
-      { requiresAuth: false },
-      {
-        credentials: "include",
-      }
-    );
+    const res = await apiClient.post<RefreshType>(REFRESH_URL, {
+      requiresAuth: false,
+      credentials: "include",
+    });
 
     const accessToken = res.data.accessToken;
     return accessToken;

--- a/src/feature/auth/components/AuthComponent.tsx
+++ b/src/feature/auth/components/AuthComponent.tsx
@@ -3,17 +3,14 @@ import NaverLoginButton from "./NaverLoginButton";
 import GoogleLoginButton from "./GoogleLoginButton";
 import { useAuthStore, type AuthModalText } from "@/lib/stores/authStore";
 import { ENV } from "@/const";
-import { generateOAuthState } from "../service";
 
 export const handleGoogleLogin = () => {
-  const state = generateOAuthState();
-  window.location.href =
-    ENV.NEW_BACKEND_URL + "/api/auth/login/google?state=" + state;
+  window.location.href = ENV.NEW_BACKEND_URL + "/api/auth/login/google";
   useAuthStore.getState().setLastProvider("google");
 };
 
 export const handleNaverLogin = () => {
-  window.location.href = ENV.BACKEND_URL + "/api/auth/login/naver";
+  window.location.href = ENV.NEW_BACKEND_URL + "/api/auth/login/naver";
   useAuthStore.getState().setLastProvider("naver");
 };
 

--- a/src/feature/auth/hooks/useLogin.tsx
+++ b/src/feature/auth/hooks/useLogin.tsx
@@ -2,7 +2,6 @@ import { useAuthStore } from "@/lib/stores/authStore";
 import { useEffect } from "react";
 import { clearURLQuery, getURLQuery } from "../\butils";
 import { refreshTokenAPI } from "../api";
-import { validateOAuthState } from "../service";
 import { toast } from "sonner";
 
 export default function useOAuthCallback() {

--- a/src/feature/auth/hooks/useLogin.tsx
+++ b/src/feature/auth/hooks/useLogin.tsx
@@ -13,7 +13,6 @@ export default function useOAuthCallback() {
   useEffect(() => {
     (async () => {
       const errorFromUrl = getURLQuery("error");
-      console.log(errorFromUrl);
       if (errorFromUrl) {
         toast.error("로그인에 실패했습니다. 다시 시도해주세요.");
         clearURLQuery();
@@ -21,18 +20,13 @@ export default function useOAuthCallback() {
       }
 
       const state = getURLQuery("state");
-      console.log(state);
       if (state) {
-        // const isValidState = validateOAuthState(state);
-        // console.log(isValidState);
-        // if (isValidState) {
         const accessToken = await refreshTokenAPI();
         if (!accessToken) return;
 
         setAccessToken(accessToken);
         setWasLoggedIn(true);
         setLastLoginTime(new Date().toISOString());
-        // }
       }
 
       clearURLQuery();

--- a/src/feature/auth/hooks/useLogin.tsx
+++ b/src/feature/auth/hooks/useLogin.tsx
@@ -19,24 +19,23 @@ export default function useOAuthCallback() {
         clearURLQuery();
         return;
       }
-      // const token = getURLQuery("access_token");
 
       const state = getURLQuery("state");
       console.log(state);
       if (state) {
-        const isValidState = validateOAuthState(state);
-        console.log(isValidState);
-        if (isValidState) {
-          const accessToken = await refreshTokenAPI();
-          if (!accessToken) return;
+        // const isValidState = validateOAuthState(state);
+        // console.log(isValidState);
+        // if (isValidState) {
+        const accessToken = await refreshTokenAPI();
+        if (!accessToken) return;
 
-          setAccessToken(accessToken);
-          setWasLoggedIn(true);
-          setLastLoginTime(new Date().toISOString());
-        }
+        setAccessToken(accessToken);
+        setWasLoggedIn(true);
+        setLastLoginTime(new Date().toISOString());
+        // }
       }
 
-      // clearURLQuery();
+      clearURLQuery();
     })();
   }, []);
 }


### PR DESCRIPTION
# [Fix] 로그인 흐름 변경

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
CSRF 방지를 위한 state 전송은 삭제했습니다. 프론트에서 전송하는 것은 위조될 수 있어 보안적으로 좋지 않고, 서버에서 검증하는 것이 옳은 OAuth 흐름이기 때문입니다. 따라서 state 관련 로직을 삭제하고 새로운 백엔드 서버 url로 변경 조치했습니다.

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- state 검증 로직 제거
- query에 state 추가 제거
- 주석 및 import 삭제
- 서버 redirect query의 state 존재 여부만 확인.

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->



### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
