### PR TITLE
[Fix]: setTokenRefresher 모듈 레벨로 이동 및 만다라트 쿼리 디버깅 콘솔 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,10 @@ import { useMandalaStore } from "./lib/stores/mandalaStore";
 import ServiceIntroCompoenent from "./feature/home/components/ServiceIntroComponent";
 import AuthProvider from "./feature/auth/components/AuthProvider";
 import MandalaBoard from "./feature/mandala/pages/MandalaBoard";
+import { apiClient } from "./lib/api/client";
+import { reissueWithRefreshToken } from "./feature/auth/service";
+
+apiClient.setTokenRefresher(reissueWithRefreshToken);
 
 function App() {
   useResize();

--- a/src/feature/auth/components/AuthProvider.tsx
+++ b/src/feature/auth/components/AuthProvider.tsx
@@ -4,8 +4,6 @@ import { useEffect, type ReactNode } from "react";
 import { toast } from "sonner";
 import useUserInfo from "../hooks/useUserInfo";
 import useOAuthCallback from "../hooks/useLogin";
-import { apiClient } from "@/lib/api/client";
-import { reissueWithRefreshToken } from "../service";
 import { performLogout } from "../hooks/useLogout";
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
@@ -13,10 +11,6 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   const setWasLoggedIn = useAuthStore((state) => state.setWasLoggedIn);
   const setLastLoginTime = useAuthStore((state) => state.setLastLoginTime);
   const setUserInfo = useAuthStore((state) => state.setUserInfo);
-
-  useEffect(() => {
-    apiClient.setTokenRefresher(reissueWithRefreshToken);
-  }, []);
 
   useOAuthCallback();
 

--- a/src/feature/mandala/hooks/useMandalaData.tsx
+++ b/src/feature/mandala/hooks/useMandalaData.tsx
@@ -10,6 +10,7 @@ export default function useMandalaData() {
   return useQuery({
     queryKey: ["mandalart"],
     queryFn: () => {
+      console.log(accessToken);
       if (!accessToken) {
         throw new Error("Mandala Data: accessToken이 없습니다.");
       }

--- a/src/feature/mandala/pages/MandalaBoard.tsx
+++ b/src/feature/mandala/pages/MandalaBoard.tsx
@@ -54,6 +54,7 @@ MandaraChartProps) {
 
   useEffect(() => {
     if (!isSuccess || !mandalartData) return;
+    console.log(accessToken);
 
     // 서버 → UI 변환
     setData(mandalartData);
@@ -64,6 +65,8 @@ MandaraChartProps) {
   }, [mandalartData, isSuccess]);
 
   useEffect(() => {
+    console.log(accessToken);
+
     if (!isError) return;
     toast.warning(
       "만다라트 대시보드를 가져오는 것에 실패했습니다. 재로그인 해주세요."


### PR DESCRIPTION
# [Fix]: setTokenRefresher 모듈 레벨로 이동 및 만다라트 쿼리 디버깅 콘솔 추가

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
 데이터베이스 환경이 바뀌면서 DB 내용이 지워져 204 응답이 전송됩니다. 그러나 로그인 흐름이 바뀌면서, 이유모를 오류를 반환하고 있습니다.  추측하기로는 타이밍 문제일 가능성이 크기 때문에 디버깅을 위한 콘솔을 추가했습니다.

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->


### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->



### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
