### PR TITLE
[Fix]: getMandalaAPI await 누락 수정

### DIFF
--- a/src/feature/mandala/hooks/useMandalaData.tsx
+++ b/src/feature/mandala/hooks/useMandalaData.tsx
@@ -9,13 +9,13 @@ export default function useMandalaData() {
 
   return useQuery({
     queryKey: ["mandalart"],
-    queryFn: () => {
-      console.log(accessToken);
+    queryFn: async () => {
+      console.log("만다라트 대시보드 쿼리", accessToken);
       if (!accessToken) {
         throw new Error("Mandala Data: accessToken이 없습니다.");
       }
 
-      const res = getMandalaAPI();
+      const res = await getMandalaAPI();
       if (res === null) {
         return emptyDummyData;
       }


### PR DESCRIPTION
# [Fix]: getMandalaAPI await 누락 수정

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
만다라트 대시보드에서 통신에 성공하지만 react query의 isError가 발생하고 있습니다. 관련 수정을 위해 쿼리 안에서 호출하는 getMandalaAPI 함수에 await을 추가했습니다. (promise 반환)
<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->


### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->



### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
