### PR TITLE
[Chore]: CI Playwright E2E 테스트 추가 및 Unit 테스트 추가

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,8 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    env:
+      VITE_NEW_BACKEND_URL: ${{ secrets.VITE_NEW_BACKEND_URL }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check dev server
-        run: |
-          PORT=4173 npm run dev &
-          sleep 15
-          curl -I http://localhost:4173
-
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 22
           cache: "npm" # node_modules도 캐싱
 
       - name: Install dependencies
@@ -31,8 +31,8 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: npx playwright install chromium
-        timeout-minutes: 10
+        run: DEBUG=pw:install npx playwright install chromium
+        timeout-minutes: 20
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,14 +18,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Debug env
-        run: echo $PLAYWRIGHT_BASE_URL
-
       - name: Check dev server
         run: |
           npm run dev &
           sleep 15
-          curl -I http://localhost:5173
+          curl -I http://localhost:4173
 
       - name: Get Playwright version
         id: playwright-version

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -42,6 +42,9 @@ jobs:
         if: steps.cache-playwright.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
+      - name: Build
+        run: npm run build
+
       - name: Run Playwright tests
         run: npx playwright test
         env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,8 +7,7 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    env:
-      VITE_NEW_BACKEND_URL: ${{ secrets.VITE_NEW_BACKEND_URL }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -16,6 +15,10 @@ jobs:
         with:
           node-version: 22
           cache: "npm" # node_modules도 캐싱
+
+      - name: Create .env
+        run: |
+          echo "${{ secrets.FRONT_ENV }}" > .env
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Check dev server
         run: |
-          npm run dev &
+          PORT=4173 npm run dev &
           sleep 15
           curl -I http://localhost:4173
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,24 +2,44 @@ name: Playwright Tests
 on:
   pull_request:
     branches: [main]
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: "npm" # node_modules도 캐싱
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+        timeout-minutes: 10
+
       - name: Run Playwright tests
         run: npx playwright test
         env:
           CI: true
-          PLAYWRIGHT_BASE_URL: http://localhost:5173 # CI용 URL
+          PLAYWRIGHT_BASE_URL: http://localhost:5173
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,7 +44,7 @@ jobs:
         run: npx playwright test
         env:
           CI: true
-          PLAYWRIGHT_BASE_URL: http://localhost:5173
+          PLAYWRIGHT_BASE_URL: http://localhost:4173
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,8 +36,11 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: DEBUG=pw:install npx playwright install chromium
+        run: npx playwright install --with-deps chromium
         timeout-minutes: 20
+      - name: Install Playwright system dependencies
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,28 @@
+name: Playwright Tests
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: http://localhost:5173 # CI용 URL
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,6 +18,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Debug env
+        run: echo $PLAYWRIGHT_BASE_URL
+
+      - name: Check dev server
+        run: |
+          npm run dev &
+          sleep 15
+          curl -I http://localhost:5173
+
       - name: Get Playwright version
         id: playwright-version
         run: echo "version=$(npm ls @playwright/test --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install Playwright Browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
         timeout-minutes: 10
 
       - name: Run Playwright tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@storybook/addon-docs": "^10.3.3",
         "@storybook/addon-vitest": "^10.3.3",
         "@storybook/react-vite": "^10.3.3",
+        "@testing-library/react": "^16.3.2",
         "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^24.3.1",
         "@types/react": "^19.1.10",
@@ -376,7 +377,6 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3831,6 +3831,33 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vike dev",
     "build": "tsc -b && vike build",
     "lint": "eslint .",
-    "preview": "vike preview",
+    "preview": "vike preview --port 4173",
     "update-sitemap": "node scripts/update-sitemap.js",
     "images": "node scripts/convert-images.js",
     "test:unit": "vitest",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@storybook/addon-docs": "^10.3.3",
     "@storybook/addon-vitest": "^10.3.3",
     "@storybook/react-vite": "^10.3.3",
+    "@testing-library/react": "^16.3.2",
     "@types/event-source-polyfill": "^1.0.5",
     "@types/node": "^24.3.1",
     "@types/react": "^19.1.10",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run build && npm run preview",
+    command: "npm run preview",
     url: "http://localhost:4173",
     reuseExistingServer: !process.env.CI,
     ignoreHTTPSErrors: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: "https://localhost:3000",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "https://localhost:3000",
     ignoreHTTPSErrors: true,
     actionTimeout: 10000,
     navigationTimeout: 10000,
@@ -75,7 +75,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "npm run dev",
-    url: "https://localhost:3000",
+    url: process.env.PLAYWRIGHT_BASE_URL ?? "https://localhost:3000",
     reuseExistingServer: !process.env.CI,
     ignoreHTTPSErrors: true,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ import { defineConfig, devices } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests",
   /* Run tests in files in parallel */
-  fullyParallel: true,
+  fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "https://localhost:3000",
+    baseURL: "https://localhost:4173",
     ignoreHTTPSErrors: true,
     actionTimeout: 10000,
     navigationTimeout: 10000,
@@ -41,15 +41,15 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
 
     /* Test against mobile viewports. */
     // {
@@ -74,9 +74,10 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
-    url: process.env.PLAYWRIGHT_BASE_URL ?? "https://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    command: "npm run dev -- --port 4173",
+    url: "http://localhost:4173",
+    reuseExistingServer: false,
     ignoreHTTPSErrors: true,
+    timeout: 120000,
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: "https://localhost:4173",
+    baseURL: "http://localhost:4173",
     ignoreHTTPSErrors: true,
     actionTimeout: 10000,
     navigationTimeout: 10000,
@@ -74,7 +74,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev -- --port 4173",
+    command: "PORT=4173 npm run dev",
     url: "http://localhost:4173",
     reuseExistingServer: false,
     ignoreHTTPSErrors: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,9 +74,9 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "PORT=4173 npm run dev",
+    command: "npm run build && npm run preview",
     url: "http://localhost:4173",
-    reuseExistingServer: false,
+    reuseExistingServer: !process.env.CI,
     ignoreHTTPSErrors: true,
     timeout: 120000,
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,13 @@ import AuthProvider from "./feature/auth/components/AuthProvider";
 import MandalaBoard from "./feature/mandala/pages/MandalaBoard";
 import { apiClient } from "./lib/api/client";
 import { reissueWithRefreshToken } from "./feature/auth/service";
+import useNetworkStatus from "./shared/hooks/useNetworkStatus";
 
 apiClient.setTokenRefresher(reissueWithRefreshToken);
 
 function App() {
   useResize();
+  useNetworkStatus();
   const { currentTheme, updateCurrentTheme, getCurrentBackground } = useTheme();
   const wasLoggedIn = useAuthStore((state) => state.wasLoggedIn);
   const isAuthOpen = useAuthStore((state) => state.isAuthOpen);

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,5 +1,4 @@
 const requiredEnvVars = {
-  BACKEND_URL: import.meta.env.VITE_BACKEND_URL,
   NEW_BACKEND_URL: import.meta.env.VITE_NEW_BACKEND_URL,
 } as const;
 

--- a/src/feature/mandala/components/modal/MandalaModal.tsx
+++ b/src/feature/mandala/components/modal/MandalaModal.tsx
@@ -64,7 +64,7 @@ export default function MandalaModal({ isModalVisible }: Props) {
   });
   UseSubsGoalNavigation();
 
-  const { startStream, isStreaming } = useSSERecommendation({
+  const { startStream, isStreaming, error } = useSSERecommendation({
     goal: subItems[0].content,
     subs: subItems,
     getAccessToken,
@@ -85,9 +85,10 @@ export default function MandalaModal({ isModalVisible }: Props) {
   });
 
   useEffect(() => {
-    console.log(`modalCellId: ${modalCellId}, content: ${subItems[0].content}`);
-    console.log(subItems);
-  }, []);
+    if (error) {
+      toast.info(error);
+    }
+  }, [error]);
 
   // 상태 관리 함수들
 
@@ -103,9 +104,6 @@ export default function MandalaModal({ isModalVisible }: Props) {
   };
 
   const handleRecommend = () => {
-    console.log("test");
-    console.log("현재 goal:", subItems[0].content);
-    console.log("현재:", subItems);
     if (!wasLoggedIn && !accessToken) {
       setAuthText({
         title: "맞춤 목표 추천을 위해 로그인해주세요",

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, act } from "@testing-library/react";
+import useSSERecommendation from "../useSSERecommendation";
+
+// EventSource Mock
+const mockEventSource = {
+  close: vi.fn(),
+
+  addEventListener: vi.fn(),
+};
+
+const MockEventSourcePolyfill = vi.fn(() => mockEventSource);
+
+vi.mock("event-source-polyfill", () => ({
+  EventSourcePolyfill: MockEventSourcePolyfill,
+}));
+
+describe("useSSERecommendation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("startStream 호출 시  EventSource를 생성한다", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("mock-token");
+
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    expect(MockEventSourcePolyfill).toHaveBeenCalledTimes(1);
+
+    expect(MockEventSourcePolyfill).toHaveBeenLastCalledWith(
+      expect.stringContaining("/api/recommend/streaming"),
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer mock-token",
+        },
+      })
+    );
+  });
+});

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import useSSERecommendation from "../useSSERecommendation";
+import useSSERecommendation, { splitSSEChunk } from "../useSSERecommendation";
 
 // EventSource Mock
 const listener: Record<string, Function> = {};
@@ -158,5 +158,43 @@ describe("useSSERecommendation", () => {
     });
     expect(onError).toHaveBeenCalledWith("스트림 연결 오류");
     expect(mocks.mockEventSource.close).toHaveBeenCalled();
+  });
+});
+
+describe("splitSSEChunk", () => {
+  it("문자 단위로 분리한다.", () => {
+    expect(
+      splitSSEChunk("50분 가량의 근력 운동을 하고 30분 유산소 하기")
+    ).toEqual([
+      "5",
+      "0",
+      "분",
+      " ",
+      "가",
+      "량",
+      "의",
+      " ",
+      "근",
+      "력",
+      " ",
+      "운",
+      "동",
+      "을",
+      " ",
+      "하",
+      "고",
+      " ",
+      "3",
+      "0",
+      "분",
+      " ",
+      "유",
+      "산",
+      "소",
+      " ",
+      "하",
+      "기",
+      ",",
+    ]);
   });
 });

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -1,17 +1,28 @@
 import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import useSSERecommendation from "../useSSERecommendation";
 
 // EventSource Mock
-const mockEventSource = {
-  close: vi.fn(),
+const mocks = vi.hoisted(() => {
+  const mockEventSource = {
+    close: vi.fn(),
+    addEventListener: vi.fn(),
 
-  addEventListener: vi.fn(),
-};
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+  };
 
-const MockEventSourcePolyfill = vi.fn(() => mockEventSource);
+  return {
+    mockEventSource,
+    MockEventSourcePolyfill: vi.fn(function () {
+      return mockEventSource;
+    }),
+  };
+});
 
 vi.mock("event-source-polyfill", () => ({
-  EventSourcePolyfill: MockEventSourcePolyfill,
+  EventSourcePolyfill: mocks.MockEventSourcePolyfill,
 }));
 
 describe("useSSERecommendation", () => {
@@ -34,9 +45,9 @@ describe("useSSERecommendation", () => {
       await result.current.startStream(3);
     });
 
-    expect(MockEventSourcePolyfill).toHaveBeenCalledTimes(1);
+    expect(mocks.MockEventSourcePolyfill).toHaveBeenCalledTimes(1);
 
-    expect(MockEventSourcePolyfill).toHaveBeenLastCalledWith(
+    expect(mocks.MockEventSourcePolyfill).toHaveBeenLastCalledWith(
       expect.stringContaining("/api/recommend/streaming"),
       expect.objectContaining({
         headers: {

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -3,14 +3,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import useSSERecommendation from "../useSSERecommendation";
 
 // EventSource Mock
+const listener: Record<string, Function> = {};
 const mocks = vi.hoisted(() => {
   const mockEventSource = {
     close: vi.fn(),
-    addEventListener: vi.fn(),
-
-    onopen: null,
-    onmessage: null,
-    onerror: null,
+    addEventListener: vi.fn((event, callback) => {
+      listener[event] = callback;
+    }),
+    onerror: null as ((event?: unknown) => void) | null,
+    onopen: null as ((event?: unknown) => void) | null,
+    onmessage: null as ((event: { data: string }) => void) | null,
   };
 
   return {
@@ -110,5 +112,51 @@ describe("useSSERecommendation", () => {
 
     expect(mocks.MockEventSourcePolyfill).not.toHaveBeenCalled();
     expect(result.current.error).toBe("추천을 위한 항목이 비어있지 않습니다.");
+  });
+
+  it("complete 이벤트 수신 시 스트림을 종료한다.", async () => {
+    const onComplete = vi.fn();
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+        onComplete,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    act(() => {
+      listener.complete();
+    });
+    expect(onComplete).toHaveBeenCalledWith(3);
+    expect(mocks.mockEventSource.close).toHaveBeenCalled();
+  });
+
+  it("error 이벤트 수신 시 스트림을 종료한다.", async () => {
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+        onError,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    act(() => {
+      mocks.mockEventSource.onerror?.({
+        type: "error",
+      });
+    });
+    expect(onError).toHaveBeenCalledWith("스트림 연결 오류");
+    expect(mocks.mockEventSource.close).toHaveBeenCalled();
   });
 });

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -93,4 +93,22 @@ describe("useSSERecommendation", () => {
     expect(mocks.MockEventSourcePolyfill).not.toHaveBeenCalled();
     expect(result.current.error).toBe("주요 목표를 작성해주세요.");
   });
+  it("count가 0이면 스트림을 생성하지 않는다", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("mock-token");
+    const count = 0;
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(count);
+    });
+
+    expect(mocks.MockEventSourcePolyfill).not.toHaveBeenCalled();
+    expect(result.current.error).toBe("추천을 위한 항목이 비어있지 않습니다.");
+  });
 });

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -209,6 +209,26 @@ describe("useSSERecommendation", () => {
       ["1", ","],
     ]);
   });
+
+  it("언마운트 시 EventSource 연결을 종료한다", async () => {
+    const { result, unmount } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "DONE" }],
+        getAccessToken: vi.fn().mockReturnValue("mock-token"),
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mocks.mockEventSource.close).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("splitSSEChunk", () => {

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -56,4 +56,41 @@ describe("useSSERecommendation", () => {
       })
     );
   });
+  it("토큰이 없으면 EventSource를 생성하지 않는다", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue(null);
+
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    expect(mocks.MockEventSourcePolyfill).not.toHaveBeenCalled();
+    expect(result.current.error).toBe("로그인 후 이용해주세요.");
+  });
+
+  it("goal이 없으면 스트림을 생성하지 않는다", async () => {
+    const getAccessToken = vi.fn().mockResolvedValue("mock-token");
+    const goal = "";
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal,
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken,
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    expect(mocks.MockEventSourcePolyfill).not.toHaveBeenCalled();
+    expect(result.current.error).toBe("주요 목표를 작성해주세요.");
+  });
 });

--- a/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
+++ b/src/feature/mandala/hooks/_tests_/useSSERecommendation.test.ts
@@ -2,6 +2,26 @@ import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import useSSERecommendation, { splitSSEChunk } from "../useSSERecommendation";
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Mandalart Store Mock
+const applyRecommendationChunk = vi.fn();
+
+vi.mock("@/lib/stores/mandalaStore", () => ({
+  useMandalaStore: (selector: any) =>
+    selector({
+      initRecommendationTargets: vi.fn(),
+      applyRecommendationChunk,
+      resetRecommendationText: vi.fn(),
+    }),
+}));
+
 // EventSource Mock
 const listener: Record<string, Function> = {};
 const mocks = vi.hoisted(() => {
@@ -158,6 +178,36 @@ describe("useSSERecommendation", () => {
     });
     expect(onError).toHaveBeenCalledWith("스트림 연결 오류");
     expect(mocks.mockEventSource.close).toHaveBeenCalled();
+  });
+  it("onmessage 이벤트 수신 시  applyRecommendationChunk 함수를 호출한다", async () => {
+    const { result } = renderHook(() =>
+      useSSERecommendation({
+        goal: "운동하기",
+        subs: [{ goalId: "1", content: "", status: "UNDONE" }],
+        getAccessToken: vi.fn().mockResolvedValue("mock-token"),
+      })
+    );
+
+    await act(async () => {
+      await result.current.startStream(3);
+    });
+
+    act(() => {
+      mocks.mockEventSource.onmessage?.({
+        data: "운동하기",
+      });
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(applyRecommendationChunk.mock.calls).toEqual([
+      ["1", "운"],
+      ["1", "동"],
+      ["1", "하"],
+      ["1", "기"],
+      ["1", ","],
+    ]);
   });
 });
 

--- a/src/feature/mandala/hooks/useSSERecommendation.tsx
+++ b/src/feature/mandala/hooks/useSSERecommendation.tsx
@@ -14,7 +14,7 @@ type UseSSERecommendationOptions = {
 
 const EventSource = EventSourcePolyfill;
 
-const splitSSEChunk = (chunk: string) => {
+export const splitSSEChunk = (chunk: string) => {
   const Queue: string[] = [];
 
   const chars = chunk.split("");

--- a/src/feature/mandala/hooks/useSSERecommendation.tsx
+++ b/src/feature/mandala/hooks/useSSERecommendation.tsx
@@ -101,7 +101,6 @@ export default function useSSERecommendation({
   const startStream = useCallback(
     async (count: number) => {
       if (!goal || goal.trim() === "") {
-        console.log(goal, subs);
         console.warn("유효하지 않은 매개변수: 주요 목표 설정 안됨.");
         setError("주요 목표를 작성해주세요.");
         return;
@@ -115,7 +114,7 @@ export default function useSSERecommendation({
       const accessToken = await getAccessToken();
       if (!accessToken) {
         console.warn("인증 토큰이 없습니다.");
-        setError("세션 종료로 인해 로그인 화면으로 돌아갑니다.");
+        setError("로그인 후 이용해주세요.");
         return;
       }
 

--- a/src/lib/stores/__tests__/fixtures/serverMandala.ts
+++ b/src/lib/stores/__tests__/fixtures/serverMandala.ts
@@ -1,0 +1,25 @@
+export const createServerMandalaFixture = () => ({
+  data: {
+    core: {
+      goalId: 1,
+      content: "자기계발",
+      status: "UNDONE" as "DONE" | "UNDONE",
+      mains: [
+        {
+          goalId: 2,
+          position: 1,
+          content: "독서",
+          status: "UNDONE" as "DONE" | "UNDONE",
+          subs: [
+            {
+              goalId: 3,
+              position: 1,
+              content: "30분 읽기",
+              status: "UNDONE" as "DONE" | "UNDONE",
+            },
+          ],
+        },
+      ],
+    },
+  },
+});

--- a/src/lib/stores/mandalaStore.ts
+++ b/src/lib/stores/mandalaStore.ts
@@ -297,6 +297,7 @@ export const useMandalaStore = create<States & Actions>()(
       handleCellChange: (cellId, value, queryData) =>
         set((state) => {
           console.log("Store handleCellChange:", cellId, value, queryData);
+
           if (cellId == null) return state;
           if (!state.data) return state;
           if (!state.data.core.mains) return state;
@@ -319,6 +320,7 @@ export const useMandalaStore = create<States & Actions>()(
               state.data.core.mains[target.mainIndex].content = value;
             }
           });
+
           // flatData cells 업데이트 추가
 
           targets.forEach((target) => {
@@ -329,7 +331,7 @@ export const useMandalaStore = create<States & Actions>()(
                 content: value,
               };
             }
-            if (subIndex) {
+            if (subIndex != null) {
               const cellId = "sub-" + mainIndex + "-" + subIndex;
               state.flatData.cells[cellId] = {
                 ...state.flatData.cells[cellId],

--- a/src/shared/hooks/useNetworkStatus.ts
+++ b/src/shared/hooks/useNetworkStatus.ts
@@ -1,0 +1,27 @@
+import { useMandalaStore } from "@/lib/stores/mandalaStore";
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+export default function useNetworkStatus() {
+  useEffect(() => {
+    const handleOffline = () => toast.error("인터넷 연결이 끊겼어요.");
+    const handleOnline = () => {
+      const changedCells = useMandalaStore.getState().changedCells;
+      if (changedCells.size > 0) {
+        toast.info(
+          "인터넷 연결이 복구됐어요. 저장되지 않은 변경사항이 있어요."
+        );
+      } else {
+        toast.success("인터넷 연결이 복구됐어요.");
+      }
+    };
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_BACKEND_URL: string;
   readonly VITE_NEW_BACKEND_URL: string;
 }
 

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { enableMapSet } from "immer";
+
+enableMapSet();

--- a/tests/helpers/mandalart.ts
+++ b/tests/helpers/mandalart.ts
@@ -6,7 +6,7 @@ export const editCell = async (page: Page, testId: string, text: string) => {
   await cell.waitFor({ state: "visible" });
   await cell.click();
   // await page.click(`[data-testid="${testId}"]`);
-
+  await page.screenshot({ path: `debug-after-click.png` });
   const textarea = page.locator("textarea");
   await textarea.waitFor({ state: "visible", timeout: 15000 });
   // await expect(textarea).toBeVisible();
@@ -26,4 +26,33 @@ export const openFullDashboard = async (page: Page) => {
   await page.click('[data-testid="full-open-button"]');
   // await page.waitForSelector('[data-testid="full-dashboard"]');
   await expect(page.locator('[data-testid="full-dashboard"]')).toBeVisible();
+};
+
+export const pressKeyboardForCell = async (
+  page: Page,
+  locator: string,
+  keys: string[]
+) => {
+  const cell = page.locator(locator);
+
+  await cell.click();
+
+  for (const key of keys) {
+    await cell.press(key);
+  }
+};
+
+// export const fillEmptyString = async (page: Page, locator: string) => {
+//   const cell = page.locator(locator);
+//   cell.fill("");
+// };
+
+export const deleteCell = async (page: Page, testId: string) => {
+  const modifier = process.platform === "darwin" ? "Meta" : "Control";
+  await pressKeyboardForCell(page, `[data-testid="${testId}"]`, [
+    `${modifier}+A`,
+    "Backspace",
+  ]);
+
+  await page.keyboard.press("Enter");
 };

--- a/tests/helpers/mandalart.ts
+++ b/tests/helpers/mandalart.ts
@@ -2,10 +2,14 @@ import { Page, expect } from "@playwright/test";
 
 export const editCell = async (page: Page, testId: string, text: string) => {
   // await page.waitForSelector(`[data-testid="${testId}"]`);
-  await page.click(`[data-testid="${testId}"]`);
-  const textarea = page.locator("textarea");
+  const cell = page.locator(`[data-testid="${testId}"]`);
+  await cell.waitFor({ state: "visible" });
+  await cell.click();
+  // await page.click(`[data-testid="${testId}"]`);
 
-  await expect(textarea).toBeVisible();
+  const textarea = page.locator("textarea");
+  await textarea.waitFor({ state: "visible" });
+  // await expect(textarea).toBeVisible();
   await expect(textarea).toBeEditable();
   // await page.waitForSelector("textarea");
   await textarea.fill(text);

--- a/tests/helpers/mandalart.ts
+++ b/tests/helpers/mandalart.ts
@@ -8,7 +8,7 @@ export const editCell = async (page: Page, testId: string, text: string) => {
   // await page.click(`[data-testid="${testId}"]`);
 
   const textarea = page.locator("textarea");
-  await textarea.waitFor({ state: "visible" });
+  await textarea.waitFor({ state: "visible", timeout: 15000 });
   // await expect(textarea).toBeVisible();
   await expect(textarea).toBeEditable();
   // await page.waitForSelector("textarea");

--- a/tests/mandalart.spec.ts
+++ b/tests/mandalart.spec.ts
@@ -1,61 +1,196 @@
 import { test, expect } from "@playwright/test";
-import { editCell, openFullDashboard, openModal } from "./helpers/mandalart";
+import {
+  deleteCell,
+  editCell,
+  openFullDashboard,
+  openModal,
+} from "./helpers/mandalart";
 
-test.describe("만다라트 셀 편집", () => {
-  test.describe.configure({ mode: "serial" });
-  test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.clear();
-      sessionStorage.clear();
-    });
-
-    await page.goto("/");
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
   });
 
-  test("핵심 목표 편집", async ({ page }) => {
-    await editCell(page, "cell-core-0", "핵심 목표");
-    await expect(page.locator('[data-testid="cell-core-0"]')).toContainText(
-      "핵심 목표"
-    );
-  });
+  await page.goto("/");
+});
+test.describe("메인 만다라트", () => {
+  // test("주요 목표 편집", async ({ page }) => {
+  //   await editCell(page, "cell-core-0", "핵심 목표");
+  //   await expect(page.locator('[data-testid="cell-core-0"]')).toContainText(
+  //     "핵심 목표"
+  //   );
+  // });
 
-  test("주요 목표 편집", async ({ page }) => {
-    await editCell(page, "cell-main-4", "주요 목표");
+  // test("주요 목표 삭제", async ({ page }) => {
+  //   await editCell(page, "cell-main-4", "주요 목표");
+
+  //   await deleteCell(page, "cell-main-4");
+
+  //   await expect(
+  //     page.locator('[data-testid="cell-main-4"]')
+  //   ).not.toContainText("주요 목표");
+  // });
+
+  test("주요 목표 편집 후 삭제", async ({ page }) => {
+    const text = `main-goal-${Date.now()}`;
+
+    await editCell(page, "cell-main-4", text);
+
     await expect(page.locator('[data-testid="cell-main-4"]')).toContainText(
-      "주요 목표"
+      text
     );
-  });
 
-  test("세부 목표 모달 열기", async ({ page }) => {
-    await editCell(page, "cell-main-3", "주요 목표");
-    await openModal(page, "main-3");
-    await page.click(`[data-testid="modal-close"]`);
-    await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
-  });
+    await deleteCell(page, "cell-main-4");
 
-  test("세부 목표 편집", async ({ page }) => {
-    await editCell(page, "cell-main-2", "주요 목표");
-    await openModal(page, "main-2");
-    await editCell(page, "modal-cell-sub-2-1", "세부 목표");
-    await expect(
-      page.locator('[data-testid="modal-cell-sub-2-1"]')
-    ).toContainText("세부 목표");
-    await page.click(`[data-testid="modal-close"]`);
-    await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
-  });
-
-  // 3. 전체 대시보드
-  test("전체 대시보드 열기", async ({ page }) => {
-    await openFullDashboard(page);
-    await page.click(`[data-testid="full-dashboard-close"]`);
-  });
-
-  test("전체 대시보드 셀 편집", async ({ page }) => {
-    await openFullDashboard(page);
-    await editCell(page, "full-cell-main-8", "핵심 목표");
-    await expect(
-      page.locator('[data-testid="full-cell-main-8"]')
-    ).toContainText("핵심 목표");
-    await page.click(`[data-testid="full-dashboard-close"]`);
+    await expect(page.locator('[data-testid="cell-main-4"]')).not.toContainText(
+      text
+    );
   });
 });
+
+test.describe("세부 만다라트 셀 편집", () => {
+  // test("세부 목표 모달 열기", async ({ page }) => {
+  //   await editCell(page, "cell-main-3", "주요 목표");
+  //   await openModal(page, "main-3");
+  //   await page.click(`[data-testid="modal-close"]`);
+  //   await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
+  // });
+
+  // test("세부 목표 편집", async ({ page }) => {
+  //   await editCell(page, "cell-main-2", "주요 목표");
+  //   await openModal(page, "main-2");
+  //   await editCell(page, "modal-cell-sub-2-1", "세부 목표");
+  //   await expect(
+  //     page.locator('[data-testid="modal-cell-sub-2-1"]')
+  //   ).toContainText("세부 목표");
+  // });
+
+  // test("세부 목표 삭제", async ({ page }) => {
+  //   await deleteCell(page, "modal-cell-sub-2-1");
+  //   await expect(
+  //     page.locator('[data-testid="modal-cell-sub-2-1"]')
+  //   ).toContainText("");
+  //   await page.click(`[data-testid="modal-close"]`);
+  //   await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
+  // });
+  test("세부 목표 편집 후 삭제", async ({ page }) => {
+    const text = `sub-goal-${Date.now()}`;
+    await editCell(page, "cell-main-3", text);
+    await openModal(page, "main-3");
+    await editCell(page, "modal-cell-sub-3-1", text);
+    await expect(
+      page.locator('[data-testid="modal-cell-sub-3-1"]')
+    ).toContainText(text);
+
+    await deleteCell(page, "modal-cell-sub-3-1");
+    await expect(
+      page.locator('[data-testid="modal-cell-sub-3-1"]')
+    ).not.toContainText(text);
+    await page.click(`[data-testid="modal-close"]`);
+    await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
+  });
+});
+
+test.describe("전체 만다라트 셀 편집", () => {
+  // test("전체 대시보드 열기", async ({ page }) => {
+  //   await openFullDashboard(page);
+  //   await page.click(`[data-testid="full-dashboard-close"]`);
+  // });
+
+  // test("전체 대시보드 셀 편집", async ({ page }) => {
+  //   await openFullDashboard(page);
+  //   await editCell(page, "full-cell-main-8", "핵심 목표");
+  //   await expect(
+  //     page.locator('[data-testid="full-cell-main-8"]')
+  //   ).toContainText("핵심 목표");
+  // });
+
+  // test("전체 목표 삭제", async ({ page }) => {
+  //   await deleteCell(page, "full-cell-main-8");
+  //   await expect(
+  //     page.locator('[data-testid="modal-cell-sub-2-1"]')
+  //   ).not.toContainText("핵심 목표");
+
+  //   await page.click(`[data-testid="full-dashboard-close"]`);
+  //   await expect(
+  //     page.locator('[data-testid="full-dashboard"]')
+  //   ).not.toBeVisible();
+  // });
+  test("전체 목표 편집 후 삭제", async ({ page }) => {
+    const text = `full-goal-${Date.now()}`;
+    await openFullDashboard(page);
+    await editCell(page, "full-cell-main-8", text);
+    await expect(
+      page.locator('[data-testid="full-cell-main-8"]')
+    ).toContainText(text);
+
+    await deleteCell(page, "full-cell-main-8");
+    await expect(
+      page.locator('[data-testid="full-cell-main-8"]')
+    ).not.toContainText(text);
+    await page.click(`[data-testid="full-dashboard-close"]`);
+    await expect(
+      page.locator('[data-testid="full-dashboard"]')
+    ).not.toBeVisible();
+  });
+});
+
+// test.describe("만다라트 셀 편집", () => {
+//   test.describe.configure({ mode: "serial" });
+//   test.beforeEach(async ({ page }) => {
+//     await page.addInitScript(() => {
+//       localStorage.clear();
+//       sessionStorage.clear();
+//     });
+
+//     await page.goto("/");
+//   });
+
+//   test("핵심 목표 편집", async ({ page }) => {
+//     await editCell(page, "cell-core-0", "핵심 목표");
+//     await expect(page.locator('[data-testid="cell-core-0"]')).toContainText(
+//       "핵심 목표"
+//     );
+//   });
+
+//   test("주요 목표 편집", async ({ page }) => {
+//     await editCell(page, "cell-main-4", "주요 목표");
+//     await expect(page.locator('[data-testid="cell-main-4"]')).toContainText(
+//       "주요 목표"
+//     );
+//   });
+
+//   test("세부 목표 모달 열기", async ({ page }) => {
+//     await editCell(page, "cell-main-3", "주요 목표");
+//     await openModal(page, "main-3");
+//     await page.click(`[data-testid="modal-close"]`);
+//     await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
+//   });
+
+//   test("세부 목표 편집", async ({ page }) => {
+//     await editCell(page, "cell-main-2", "주요 목표");
+//     await openModal(page, "main-2");
+//     await editCell(page, "modal-cell-sub-2-1", "세부 목표");
+//     await expect(
+//       page.locator('[data-testid="modal-cell-sub-2-1"]')
+//     ).toContainText("세부 목표");
+//     await page.click(`[data-testid="modal-close"]`);
+//     await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
+//   });
+
+//   // 3. 전체 대시보드
+//   test("전체 대시보드 열기", async ({ page }) => {
+//     await openFullDashboard(page);
+//     await page.click(`[data-testid="full-dashboard-close"]`);
+//   });
+
+//   test("전체 대시보드 셀 편집", async ({ page }) => {
+//     await openFullDashboard(page);
+//     await editCell(page, "full-cell-main-8", "핵심 목표");
+//     await expect(
+//       page.locator('[data-testid="full-cell-main-8"]')
+//     ).toContainText("핵심 목표");
+//     await page.click(`[data-testid="full-dashboard-close"]`);
+//   });
+// });

--- a/tests/mandalart.spec.ts
+++ b/tests/mandalart.spec.ts
@@ -15,23 +15,6 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
 });
 test.describe("메인 만다라트", () => {
-  // test("주요 목표 편집", async ({ page }) => {
-  //   await editCell(page, "cell-core-0", "핵심 목표");
-  //   await expect(page.locator('[data-testid="cell-core-0"]')).toContainText(
-  //     "핵심 목표"
-  //   );
-  // });
-
-  // test("주요 목표 삭제", async ({ page }) => {
-  //   await editCell(page, "cell-main-4", "주요 목표");
-
-  //   await deleteCell(page, "cell-main-4");
-
-  //   await expect(
-  //     page.locator('[data-testid="cell-main-4"]')
-  //   ).not.toContainText("주요 목표");
-  // });
-
   test("주요 목표 편집 후 삭제", async ({ page }) => {
     const text = `main-goal-${Date.now()}`;
 
@@ -50,30 +33,6 @@ test.describe("메인 만다라트", () => {
 });
 
 test.describe("세부 만다라트 셀 편집", () => {
-  // test("세부 목표 모달 열기", async ({ page }) => {
-  //   await editCell(page, "cell-main-3", "주요 목표");
-  //   await openModal(page, "main-3");
-  //   await page.click(`[data-testid="modal-close"]`);
-  //   await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
-  // });
-
-  // test("세부 목표 편집", async ({ page }) => {
-  //   await editCell(page, "cell-main-2", "주요 목표");
-  //   await openModal(page, "main-2");
-  //   await editCell(page, "modal-cell-sub-2-1", "세부 목표");
-  //   await expect(
-  //     page.locator('[data-testid="modal-cell-sub-2-1"]')
-  //   ).toContainText("세부 목표");
-  // });
-
-  // test("세부 목표 삭제", async ({ page }) => {
-  //   await deleteCell(page, "modal-cell-sub-2-1");
-  //   await expect(
-  //     page.locator('[data-testid="modal-cell-sub-2-1"]')
-  //   ).toContainText("");
-  //   await page.click(`[data-testid="modal-close"]`);
-  //   await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
-  // });
   test("세부 목표 편집 후 삭제", async ({ page }) => {
     const text = `sub-goal-${Date.now()}`;
     await editCell(page, "cell-main-3", text);
@@ -93,30 +52,6 @@ test.describe("세부 만다라트 셀 편집", () => {
 });
 
 test.describe("전체 만다라트 셀 편집", () => {
-  // test("전체 대시보드 열기", async ({ page }) => {
-  //   await openFullDashboard(page);
-  //   await page.click(`[data-testid="full-dashboard-close"]`);
-  // });
-
-  // test("전체 대시보드 셀 편집", async ({ page }) => {
-  //   await openFullDashboard(page);
-  //   await editCell(page, "full-cell-main-8", "핵심 목표");
-  //   await expect(
-  //     page.locator('[data-testid="full-cell-main-8"]')
-  //   ).toContainText("핵심 목표");
-  // });
-
-  // test("전체 목표 삭제", async ({ page }) => {
-  //   await deleteCell(page, "full-cell-main-8");
-  //   await expect(
-  //     page.locator('[data-testid="modal-cell-sub-2-1"]')
-  //   ).not.toContainText("핵심 목표");
-
-  //   await page.click(`[data-testid="full-dashboard-close"]`);
-  //   await expect(
-  //     page.locator('[data-testid="full-dashboard"]')
-  //   ).not.toBeVisible();
-  // });
   test("전체 목표 편집 후 삭제", async ({ page }) => {
     const text = `full-goal-${Date.now()}`;
     await openFullDashboard(page);
@@ -135,62 +70,3 @@ test.describe("전체 만다라트 셀 편집", () => {
     ).not.toBeVisible();
   });
 });
-
-// test.describe("만다라트 셀 편집", () => {
-//   test.describe.configure({ mode: "serial" });
-//   test.beforeEach(async ({ page }) => {
-//     await page.addInitScript(() => {
-//       localStorage.clear();
-//       sessionStorage.clear();
-//     });
-
-//     await page.goto("/");
-//   });
-
-//   test("핵심 목표 편집", async ({ page }) => {
-//     await editCell(page, "cell-core-0", "핵심 목표");
-//     await expect(page.locator('[data-testid="cell-core-0"]')).toContainText(
-//       "핵심 목표"
-//     );
-//   });
-
-//   test("주요 목표 편집", async ({ page }) => {
-//     await editCell(page, "cell-main-4", "주요 목표");
-//     await expect(page.locator('[data-testid="cell-main-4"]')).toContainText(
-//       "주요 목표"
-//     );
-//   });
-
-//   test("세부 목표 모달 열기", async ({ page }) => {
-//     await editCell(page, "cell-main-3", "주요 목표");
-//     await openModal(page, "main-3");
-//     await page.click(`[data-testid="modal-close"]`);
-//     await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
-//   });
-
-//   test("세부 목표 편집", async ({ page }) => {
-//     await editCell(page, "cell-main-2", "주요 목표");
-//     await openModal(page, "main-2");
-//     await editCell(page, "modal-cell-sub-2-1", "세부 목표");
-//     await expect(
-//       page.locator('[data-testid="modal-cell-sub-2-1"]')
-//     ).toContainText("세부 목표");
-//     await page.click(`[data-testid="modal-close"]`);
-//     await expect(page.locator('[data-testid="modal"]')).not.toBeVisible();
-//   });
-
-//   // 3. 전체 대시보드
-//   test("전체 대시보드 열기", async ({ page }) => {
-//     await openFullDashboard(page);
-//     await page.click(`[data-testid="full-dashboard-close"]`);
-//   });
-
-//   test("전체 대시보드 셀 편집", async ({ page }) => {
-//     await openFullDashboard(page);
-//     await editCell(page, "full-cell-main-8", "핵심 목표");
-//     await expect(
-//       page.locator('[data-testid="full-cell-main-8"]')
-//     ).toContainText("핵심 목표");
-//     await page.click(`[data-testid="full-dashboard-close"]`);
-//   });
-// });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,10 +76,11 @@ export default ({ mode }: { mode: string }) => {
           target: env.VITE_NEW_BACKEND_URL,
           changeOrigin: true,
           secure: false,
+          cookieDomainRewrite: "localhost",
         },
       },
       host: true,
-      port: 3000,
+      port: Number(process.env.PORT) || 3000,
       allowedHosts: [".ngrok-free.app"],
     },
   });


### PR DESCRIPTION
# [Chore]: CI Playwright E2E 테스트 추가 및 Unit 테스트 추가

<!--
제목 작성 시 형식 예시: [feat/fix/refactor/chore] 간결하게 변경 내용 요약
- feat: 새로운 기능 추가
- fix: 버그 수정
- refactor: 코드/폴더 구조 리팩토링 (기능 변화 없음)
- chore: 문서, 빌드, 설정 등 기타 변경
-->

# 추가된 내용 (Description)
main 브랜치에 PR을 올리면, 자동으로 테스트가 작동하는 github action script를 추가했습니다. 또한 error 토스트 알림이 동작하도록 useEffect를 추가하였고, 디버깅을 위한 console.log는 삭제했습니다. E2E 테스트를 위한 CI 설정 및 자동화에서 일어나는 문제를 해결했습니다. (PORT 충돌/preview 실행) 만다라트 대시보드 셀 편집,삭제,입력 테스트가 자동으로 실행됩니다.

만다라트 대시보드 관련한 유닛 테스트를 추가했습니다. 목표 추천 시 작동하는 스트림 실행/종료/이벤트(메세지)를 테스트합니다. 관련하여 입력 검증, 토큰 유무, 주요 목표 유무 등의 유효성 검사를 추가했습니다. 추가적으로 만다라트 대시보드 상태 관리 스토어 함수의 테스트를 작성했습니다. 

<br/>
<br/>
<br/>

# 변경 사항
<!-- 무엇을 변경했는지 -->
<!-- 파일 이름 및 경로 등 자유롭게 기술 -->
<!-- 예: 로그인 로직 추가, 상태 관리 개선 -->
- test script 추가 (main 브랜치에 PR)
- 대시보드 저장 시 error toast 알림 추가
- console.log 삭제
- E2E 테스트의 CI 환경 설정 및 CI 환경에서 발생하는 문제 해결
- 만다라트 대시보드의 입력,삭제,편집 테스트 추가

- 목표 추천 유닛 테스트 추가
  - 목표 추천 시 스트림 실행/삭제/이벤트 환경 테스트
  - 입력 검증, 토큰 유무, 주요 목표 유무 등의 유효성 검사 및 순수 함수 테스트 추가
- 만다라트 대시보드 상태관리 스토어 테스트 추가
  - 테스트용 Fixture 데이터 추가
  - subIndex가 0일 때 false가 일어날 예외 케이스 제거

### 왜 변경했는지 (배경/문제점):
<!-- 예: 기존 로그인 로직에서 refresh token 처리 누락 문제 해결 -->



### 사이드 이펙트 / 주의 사항
<!-- 예: handleLogin 시 브라우저 history가 변경됨, API 호출 실패 시 handleLogout 실행 -->


# 참고
### 관련 이슈 번호:
<!-- 예: #123 -->
- 없음

### 참고 문서/디자인 가이드:
<!-- 예: [Notion 로그인 API 문서](링크) -->
